### PR TITLE
Improve typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,22 @@
 declare module 'css-ns' {
-  interface Options {
+  interface Options<R = undefined> {
     namespace: string;
     prefix?: string;
     include?: RegExp;
     exclude?: RegExp;
     self?: RegExp;
     glue?: string;
-    React?: any;
+    React?: R;
   }
 
   type ClassMap = { [className: string]: boolean };
   type ReactElement = any;
 
-  export interface NsFunction {
+  export interface NsFunction<R = undefined> {
     (classNames: string | any[] | ClassMap): string;
     <T extends ReactElement>(reactElement: T): T;
+    React: R;
   }
 
-  export const createCssNs: (options: Options | string) => NsFunction;
+  export const createCssNs: <R = undefined>(options: Options<R> | string) => NsFunction<R>;
 }


### PR DESCRIPTION
This change makes it only compatible with TS >= 2.3, but it gives the following improvements:

```ts
const { React } = createCssNs({ namespace: 'foo' }); // React is `undefined`
```
```ts
import * as React from 'react';
const { React } = createCssNs({ namespace: 'foo', React }); // React is `React`
```